### PR TITLE
chore: update start npm scripts for local development

### DIFF
--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -13,7 +13,8 @@
     "clean": "rm -rf dist",
     "compile": "npm run tsc",
     "tsc": "tsc -p .",
-    "rollup": "rollup -c"
+    "rollup": "rollup -c",
+    "start": "npm run tsc --watch"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.es.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -18,7 +18,8 @@
     "prebuild": "mkdir -p ../../build/wc",
     "build": "stencil build --docs",
     "postbuild": "cp -r ./dist/* ../../build/wc",
-    "start": "stencil build --dev --watch --serve",
+    "start": "stencil build --watch",
+    "serve": "stencil build --dev --watch --serve",
     "test": "stencil test --spec --e2e",
     "test.watch": "stencil test --spec --e2e --watchAll",
     "generate": "stencil generate"


### PR DESCRIPTION
Local client development can be started through lerna as
```
lerna run start --parallel
```